### PR TITLE
[HOTFIX] 프로필 페이지 useCallback 에러

### DIFF
--- a/src/components/ProfileAward/ProfileAward.tsx
+++ b/src/components/ProfileAward/ProfileAward.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import styles from './ProfileAward.module.css';
 
 function ProfileAward({


### PR DESCRIPTION
useCallback is not defined
- ProfileAward 컴포넌트에서 useCallback을 import 하지 않아서 발생한 문제